### PR TITLE
Add vertical size to match text

### DIFF
--- a/ch14p388constraints/ch14p382autoresizing/AppDelegate.m
+++ b/ch14p388constraints/ch14p382autoresizing/AppDelegate.m
@@ -95,7 +95,7 @@
       options:0 metrics:nil views:vs]];
     [v1 addConstraints:
      [NSLayoutConstraint
-      constraintsWithVisualFormat:@"V:[v3]|"
+      constraintsWithVisualFormat:@"V:[v3(20)]|"
       options:0 metrics:nil views:vs]];
     
 #endif


### PR DESCRIPTION
The program doesn't reflect the initial state in the text, which is confusing until you read further ("which" could also be changed back to 1).
