### PR TITLE
added an example of numeric literal 

### DIFF
--- a/bk1ch04p164polymorphism/bk1ch04p164polymorphism/ViewController.swift
+++ b/bk1ch04p164polymorphism/bk1ch04p164polymorphism/ViewController.swift
@@ -122,6 +122,7 @@ class ViewController: UIViewController {
             let i = ud.object(forKey: "Test") as! Int
             _ = i
             let s : NSString = "howdy" // so why isn't it required here???
+            let iiii: NSNumber = 1 // it isn't required here either because it's a numeric literal
             // maybe it will be, but not now?
             _ = s
         }


### PR DESCRIPTION
Dear Matt Neuburg:
Thank you so much for your great contribution on all of the iOS books you've published. 
In your latest book iOS 10 Programming Fundamentals with Swift on page 173 about the statement on bridging from a Swift type to a bridged Objective-C type:"In Swift 3, in general, to cross the bridge from a Swift type to a bridged Objective-C type, you will need to cast explicitly (except in the case of a string literal)". I found not only string literal, but also numeric literal is not required to be cast explicitly when cross the bridge from a Swift type to a bridged Objective-C type. So the fourth example "let i : NSNumber = 1 as NSNumber   // Int to NSNumber" can also be written as "let i : NSNumber = 1 ". I tested it on both Xcode 8.3.3 and Xcode 9. I was wondering if it's a mistake or not. I'm so sorry for taking your time.